### PR TITLE
NeoForge: fix Items init before ARMOR_MATERIAL registry freezes

### DIFF
--- a/common/src/main/java/immersive_armors/ItemGroups.java
+++ b/common/src/main/java/immersive_armors/ItemGroups.java
@@ -5,6 +5,12 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
 public class ItemGroups {
+    private static boolean itemsReady;
+
+    public static void markItemsReady() {
+        itemsReady = true;
+    }
+
     public static ResourceLocation getIdentifier() {
         return Main.locate(Main.MOD_ID + "_tab");
     }
@@ -14,6 +20,9 @@ public class ItemGroups {
     }
 
     public static ItemStack getIcon() {
+        if (!itemsReady) {
+            return new ItemStack(net.minecraft.world.item.Items.IRON_HELMET);
+        }
         return Items.items.getOrDefault("divine_chestplate", () -> net.minecraft.world.item.Items.IRON_HELMET).get().getDefaultInstance();
     }
 }

--- a/common/src/main/java/immersive_armors/Items.java
+++ b/common/src/main/java/immersive_armors/Items.java
@@ -147,7 +147,7 @@ public interface Items {
             .equipSound(SoundEvents.REDSTONE_TORCH_BURNOUT));
 
     static void bootstrap() {
-
+        ItemGroups.markItemsReady();
     }
 
     static ExtendedArmorMaterial registerSet(ExtendedArmorMaterial material) {

--- a/neoforge/src/main/java/immersive_armors/neoforge/CommonNeoForge.java
+++ b/neoforge/src/main/java/immersive_armors/neoforge/CommonNeoForge.java
@@ -3,6 +3,7 @@ package immersive_armors.neoforge;
 import immersive_armors.*;
 import immersive_armors.neoforge.cobalt.network.NetworkHandlerImpl;
 import immersive_armors.neoforge.cobalt.registration.RegistrationImpl;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -16,7 +17,6 @@ import net.neoforged.neoforge.registries.RegisterEvent;
 import static net.minecraft.core.registries.BuiltInRegistries.CREATIVE_MODE_TAB;
 
 @Mod(Main.MOD_ID)
-@EventBusSubscriber(modid = Main.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public final class CommonNeoForge {
     static {
         Main.FORGE = true;
@@ -26,16 +26,17 @@ public final class CommonNeoForge {
 
     public CommonNeoForge(IEventBus bus) {
         new RegistrationImpl(bus);
-
         LootProvider.initialize(bus);
-
+        bus.addListener(CommonNeoForge::onRegistryEvent);
         DEF_REG.register(bus);
     }
 
     static boolean onlyOnce = true;
 
-    @SubscribeEvent
     public static void onRegistryEvent(RegisterEvent event) {
+        if (!event.getRegistryKey().equals(Registries.ARMOR_MATERIAL)) {
+            return;
+        }
         if (onlyOnce) {
             onlyOnce = false;
             Items.bootstrap();
@@ -54,8 +55,11 @@ public final class CommonNeoForge {
             .build()
     );
 
-    @SubscribeEvent
-    public static void register(final RegisterPayloadHandlersEvent event) {
-        CommonNeoForge.NETWORK_HANDLER.register(event);
+    @EventBusSubscriber(modid = Main.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+    static final class PayloadRegistration {
+        @SubscribeEvent
+        public static void register(RegisterPayloadHandlersEvent event) {
+            CommonNeoForge.NETWORK_HANDLER.register(event);
+        }
     }
 }


### PR DESCRIPTION
Register RegisterEvent from the @Mod constructor so it is not missed when @EventBusSubscriber attaches late. Run Items.bootstrap only on the minecraft:armor_material pass. Defer ItemGroups#getIcon from touching Items until bootstrap completes so creative tab icon cannot trigger premature Items static init. Keep payload registration on a nested @EventBusSubscriber.